### PR TITLE
#162725271  Enable user to share articles on different platforms

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -4,6 +4,8 @@ from authors.apps.profiles.models import Profile
 from authors.apps.profiles.serializers import UserProfileSerializer
 from authors.apps.utils.estimator import article_read_time
 
+from authors.apps.utils.share_links import share_links_generator
+from django.urls import reverse
 class AuthorProfileSerializer(UserProfileSerializer):
 
     class Meta:
@@ -15,21 +17,27 @@ class ArticleSerializer(serializers.ModelSerializer):
 
     author = AuthorProfileSerializer(read_only=True)
     read_time = serializers.SerializerMethodField()
+    share_links = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
         fields = ('title', 'slug', 'description', 'created_at',
                   'updated_at', 'favorited', 'favoritesCount',
-                  'body', 'image', 'author','read_time')
+                  'body', 'image', 'author','read_time','share_links')
 
 
     def get_read_time(self,obj):
         return article_read_time(obj.body)
 
+    def get_author(self, obj):
+        return obj.author.id
+    def get_share_links(self,obj):
+       return share_links_generator(obj,self.context['request'])
 
 class ArticleUpdateSerializer(serializers.ModelSerializer):
     author = AuthorProfileSerializer(read_only=True)
     read_time = serializers.SerializerMethodField()
+    share_links = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
@@ -43,7 +51,11 @@ class ArticleUpdateSerializer(serializers.ModelSerializer):
             'favoritesCount',
             'image',
             'author',
-            'read_time'
+            'read_time',
+            'share_links'
         ]
     def get_read_time(self,obj):
         return article_read_time(obj.body)
+      
+    def get_share_links(self,obj):
+        return share_links_generator(obj,self.context['request'])

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -31,7 +31,12 @@ class ArticleUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
     """ Updates and deletes an article instance """
     serializer_class = ArticleUpdateSerializer
     permission_class = (IsAuthenticated,)
+    renderer_classes = (ArticleJSONRenderer,)
 
+    def get_serializer_context(self):
+        return {
+            'request': self.request
+        }
     def get_object(self):
         slug = self.kwargs.get('slug')
         return get_object_or_404(Article, slug=slug)

--- a/authors/apps/utils/share_links.py
+++ b/authors/apps/utils/share_links.py
@@ -1,0 +1,33 @@
+
+import urllib.parse
+from django.urls import reverse
+def share_links_generator(obj,request):
+    """ 
+    Generates sharing links for popular plaforms
+    like facebook, googleplus, twitter and email
+
+    Args:
+        article_title(String): title of article to share
+        article_link(String): http link to article
+    
+    returns 
+        share_links(dict): collection of sharing links
+    
+    """
+    share_links = {}
+    article_title = obj.title
+    article_link = request\
+                .build_absolute_uri(reverse('articles:article-update',\
+                kwargs={'slug':obj.slug}))
+    
+    encoded_article_link = urllib.parse.quote(article_link)
+    encoded_article_title = urllib.parse.quote(article_title)
+
+    share_links['facebook'] = 'https://www.facebook.com/sharer/sharer.php?u='+encoded_article_link
+    share_links['twitter'] = 'https://twitter.com/home?status='+encoded_article_link
+    share_links['gplus'] = 'https://plus.google.com/share?url='+encoded_article_link
+    share_links['email'] = 'mailto:?&subject='+encoded_article_title+'&body='\
+                            +encoded_article_title+'%0A%0A'+encoded_article_link
+    return share_links
+
+


### PR DESCRIPTION
#### What does this PR do?
This PR adds functionality for articles to be sharable on different social media platforms

#### Description of Task to be completed?
Modify fetch articles endpoint to have 
```
{
"share_links": {
                "facebook": <facebook_share_link>,
                "gplus": <gplus_share_link>,
                "email": <email_share_link>
            }
}
```

#### How should this be manually tested?
 - fetch and checkout into this branch with: ` git fetch origin ft-share-articles-162725271 && git checkout ft-share-articles-162725271`
- activate your virtual environment
- Get articles from endpoint`{{url}}/api/articles` as an authenticated user.

##### Important Note: 
Sharable links for FB and google plus might not work well with localhost. use [this link](https://ah-backend-xmen.herokuapp.com) app to test is with a deployed app

#### What are the relevant pivotal tracker stories?
[#162725271](https://www.pivotaltracker.com/story/show/162725271)
#### Screenshots 

<img width="1127" alt="screen shot 2019-01-21 at 4 17 31 pm" src="https://user-images.githubusercontent.com/17139402/51476997-22f18980-1d98-11e9-98be-168a9a7da73d.png">

#### POSTMAN

[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/428039a8ebab19d7470c)
