### PR TITLE
#162725268 Add article pagination support

### DIFF
--- a/authors/apps/articles/paginators.py
+++ b/authors/apps/articles/paginators.py
@@ -1,0 +1,6 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class ArticleLimitOffSetPagination(LimitOffsetPagination):
+    default_limit = 10
+    offset_query_param = 'page'

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -2,14 +2,16 @@ from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 from .models import Article
 from django.shortcuts import get_object_or_404
-from rest_framework import serializers
 from .serializers import ArticleSerializer, ArticleUpdateSerializer
 from .renderers import ArticleJSONRenderer
 from rest_framework import status
 from rest_framework.response import Response
 from authors.apps.utils.messages import error_messages
 from authors.apps.profiles.models import Profile
-from authors.apps.utils.custom_permissions.permissions import check_if_is_author
+from authors.apps.utils.custom_permissions.permissions import (
+    check_if_is_author,
+)
+from .paginators import ArticleLimitOffSetPagination
 
 
 class ArticleListCreateView(generics.ListCreateAPIView):
@@ -17,6 +19,7 @@ class ArticleListCreateView(generics.ListCreateAPIView):
     serializer_class = ArticleSerializer
     permission_classes = (IsAuthenticated,)
     renderer_classes = (ArticleJSONRenderer,)
+    pagination_class = ArticleLimitOffSetPagination
 
     def perform_create(self, serializer):
         serializer.save(
@@ -44,5 +47,6 @@ class ArticleUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
         instance = self.get_object()
         check_if_is_author(instance, self.request)
         self.perform_destroy(instance)
-        return Response({"message": error_messages['delete_msg'].format('Article')},
-                        status=status.HTTP_200_OK)
+        return Response(
+            {"message": error_messages['delete_msg'].format('Article')},
+            status=status.HTTP_200_OK)

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -172,7 +172,6 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
-
 }
 
 


### PR DESCRIPTION
### What does this PR do?
This PR adds pagination support for the articles

### Description of Task to be completed?
Numerous articles make it hard for the reader to scroll down the screen. This PR is meant to improve article readability by introducing pages to the articles.

### How should this be manually tested?
- fetch this branch by running the command `git fetch origin ft-article-pagination-support-162725268` in the terminal.
- check into the branch `git checkout ft-article-pagination-support-162725268`
- start the virtual environment `source venv/bin/activate`
- re-install requirements `pip install -r requirements.txt`
- start the application `python manage.py runserver`
- Run postman and test the links as shown in the screenshots below
- Set the number of articles for each page using `api/articles/?limit=<integer>&page=<integer>`

### What are the relevant pivotal tracker stories?
[#162725268](https://www.pivotaltracker.com/n/projects/2232225/stories/162725268)

### Screen shots
<img width="1126" alt="screen shot 2019-01-22 at 4 10 54 pm" src="https://user-images.githubusercontent.com/39744587/51537750-74654b80-1e60-11e9-80ac-a4407517c209.png">

### Postman
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4000a40852668974b80d)