### PR TITLE
#163567754: make page index start at one

### DIFF
--- a/authors/apps/articles/paginators.py
+++ b/authors/apps/articles/paginators.py
@@ -1,6 +1,7 @@
-from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.pagination import PageNumberPagination
 
 
-class ArticleLimitOffSetPagination(LimitOffsetPagination):
-    default_limit = 10
-    offset_query_param = 'page'
+class ArticlePageNumberPagination(PageNumberPagination):
+    page_size = 10
+    page_query_param = 'page'
+    page_size_query_param = 'limit'

--- a/authors/apps/articles/views/bookmark_views.py
+++ b/authors/apps/articles/views/bookmark_views.py
@@ -31,7 +31,8 @@ class BookmarkAPIView(generics.GenericAPIView):
             if bookmark.article.slug == slug:
                 raise serializers.ValidationError('Article already bookmarked')
         new_bookmark = Bookmark.objects.create(article=article, profile=me)
-        return Response({'message': 'Article added to bookmarks'}, status=status.HTTP_200_OK)
+        return Response({'message': 'Article added to bookmarks'},
+                        status=status.HTTP_200_OK)
 
     def delete(self, request, slug):
         article, me, bookmarks = self.fetch_required_params(request, slug)

--- a/authors/apps/articles/views/views.py
+++ b/authors/apps/articles/views/views.py
@@ -16,12 +16,11 @@ from authors.apps.profiles.models import Profile
 from authors.apps.utils.custom_permissions.permissions import (
     check_if_is_author, can_report
 )
-from authors.apps.articles.paginators import ArticleLimitOffSetPagination
+from authors.apps.articles.paginators import ArticlePageNumberPagination
 from authors.apps.articles.utils import get_like_status, get_usernames
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
 from authors.apps.articles.filters import ArticleFilter
-
 from authors.apps.notifications.backends import notify
 
 
@@ -30,7 +29,7 @@ class ArticleListCreateView(generics.ListCreateAPIView):
     serializer_class = ArticleSerializer
     renderer_classes = (ArticleJSONRenderer,)
     permission_classes = (IsAuthenticated, )
-    pagination_class = ArticleLimitOffSetPagination
+    pagination_class = ArticlePageNumberPagination
     filter_backends = (DjangoFilterBackend, SearchFilter, OrderingFilter)
     search_fields = ('title', 'body', 'description', 'author__user__username')
     filter_class = ArticleFilter
@@ -125,7 +124,7 @@ class ArticleLikesView(generics.RetrieveUpdateDestroyAPIView):
                 user=user, article=article_id, like_article=like_article)
             like.save()
             notify.article_interaction_liked_or_faved(
-                request,like.article,liked_by=like.user.profile
+                request, like.article, liked_by=like.user.profile
             )
 
             if ArticleLikes.objects.filter(
@@ -265,7 +264,7 @@ class FavoriteHandlerView(generics.GenericAPIView):
         else:
             message = Response({
             "message": Article.objects.handle_favorite_actions(
-                request_user_obj=loggedin_user,article_slug=article.slug)
+                request_user_obj=loggedin_user, article_slug=article.slug)
         }, status=status.HTTP_200_OK)
         notify.article_interaction_liked_or_faved(self.request,article,favorited_by=loggedin_user.profile)
         return message


### PR DESCRIPTION
### What does this PR do?
Make page index start at one instead of zero
### Description of Task to be completed?
The current index of the articles paginators starts at zero. Index zero should not return any value. You should make the paginator start from one
### How should this be manually tested?
- Fetch this branch using `git fetch origin ft-paginator-index-163567754` 
- Check out the branch using `git checkout ft-paginator-index-163567754`
- Create virtual environment using virtualenv <envname> and activate it using `source <envname>/bin/activate`
- To start the application, run `python manage.py runserver in terminal`.
- Open postman and run the GET method `http://localhost:8000/api/articles/?page=0`
### Related Pivotal Tracker Stories
[#163567754](https://www.pivotaltracker.com/n/projects/2232225/stories/163567754)