### PR TITLE
#163583000 Add authentication to API swagger documentation

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -136,7 +136,7 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-class RequestPasswordResetAPIView(APIView):
+class RequestPasswordResetAPIView(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = PasswordResetRequestSerializer
@@ -156,7 +156,7 @@ class RequestPasswordResetAPIView(APIView):
         return Response({'message':'Email sent. Please check your inbox for a password reset email.'}, status = status.HTTP_200_OK)
        
 
-class ResetPasswordAPIView(APIView):
+class ResetPasswordAPIView(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = PasswordResetSerializer
@@ -185,7 +185,7 @@ class ResetPasswordAPIView(APIView):
         return Response({"password-reset":"Your password has been updated"}, status=status.HTTP_200_OK)
         
 
-class FacebookLoginAPIview(APIView):
+class FacebookLoginAPIview(GenericAPIView):
     permission_classes = (AllowAny,)
     serializer_class = FacebookSocialAuthSerializer
     renderer_classes = (UserJSONRenderer,)
@@ -201,7 +201,7 @@ class FacebookLoginAPIview(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
         
 
-class GoogleLoginAPIview(APIView):
+class GoogleLoginAPIview(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = GoogleSocialAuthSerializer
@@ -217,7 +217,7 @@ class GoogleLoginAPIview(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
         
 
-class TwitterLoginAPIview(APIView):
+class TwitterLoginAPIview(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = TwitterSocialAuthSerializer

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -190,3 +190,13 @@ EMAIL_USE_TLS = True
 EMAIL_PORT = 587
 EMAIL_HOST_USER = config('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
+
+SWAGGER_SETTINGS = {
+   'SECURITY_DEFINITIONS': {
+      'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+      }
+   }
+}

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -31,6 +31,7 @@ schema_view = get_schema_view(
         contact=openapi.Contact(email="contact@snippets.local"),
         license=openapi.License(name="BSD License"),
     ),
+    public=True,
     permission_classes=(AllowAny,),
 )
 urlpatterns = [


### PR DESCRIPTION
#### What does this PR do?
This PR enables users to access protected routes on the API swagger documentation using their authentication credentials.

#### Description of Task to be completed?
- Add security definitions to the swagger settings to upload authorization functionality
- Append the swagger settings to the project's settings.py file
- Configure a few endpoints to capture their functionality as well as parameters

#### How should this be manually tested?

To Test this follow the steps below:
- Fetch and check into this branch with `git fetch origin bg-Add-authentication-to-swagger-163583000 && git checkout bg-Add-authentication-to-swagger-163583000`
- Activate your virtual environment by running `source venv/bin/activate`
- Start the application by running `python manage.py runserver`
- To access the documentation click this [link](http://127.0.0.1:8000/api/documentation/)
To access the protected routes
- Login a registered user then copy the Token from the response body.
- Click the Authorize button and input `Bearer` plus  __Copied Token__ then you can access the protected routes

#### What are the relevant pivotal tracker stories?
[#163583000](https://www.pivotaltracker.com/story/show/163583000)
