### PR TITLE
#163591958 A following count should return for a given profile

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -36,10 +36,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
             obj(instance): This is a profile instance of a user
 
         """
-        followers = []
-        for user in list(obj.followers.all()):
-            followers.append(user.username)
-        return len(followers)
+        return len(list(obj.followers.all()))
+            
+        
 
     def get_following(self,obj):
         """
@@ -49,17 +48,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
             obj(instance): This is a profile instance of a user
 
         """
-        following = []
-        visitor = None
-        request = self.context.get("request")
-        if not request:
-            return 
-        if not isinstance(request.user, User):
-            return
-        visitor = request.user
-        for profile in visitor.is_following.all():
-            following.append(profile.user.username)
-        return len(following)
+        return len(list(obj.user.is_following.all()))
 
     def get_is_following(self,obj):
         """


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the logic for returning the count of author profiles a user is following as well as their followers. 

#### Description of task to be completed
Retrieve the length of the lists of followers and people a user is following in their profiles. 

#### How should this be manually tested?
- Fetch this branch in your terminal and check out into it using `git fetch origin bg-following-count-163591958 && git checkout bg-following-count-163591958`
- Start the application by running the server with `python manage.py runserver`
- To test the endpoint: 
   - first, follow a user using `POST/api/profiles/<username-to-follow>/follow`
   - then, check both the follower and followed users' profiles to see their following counts by using `GET/api/profiles/<username>`

#### Screenshots
<img width="1131" alt="screen shot 2019-01-30 at 6 47 29 pm" src="https://user-images.githubusercontent.com/31903212/51993438-eb818c00-24bf-11e9-96e9-45e3ab2f01fe.png">
<img width="1138" alt="screen shot 2019-01-30 at 6 48 37 pm" src="https://user-images.githubusercontent.com/31903212/51993440-eb818c00-24bf-11e9-950b-bf7d8183a6e8.png">

#### Related Pivotal Tracker Story
[#163591958](https://www.pivotaltracker.com/story/show/163591958)