### PR TITLE
#163956897 Email links should redirect to the front end

### DIFF
--- a/authors/apps/authentication/tests_/test_user_endpoints.py
+++ b/authors/apps/authentication/tests_/test_user_endpoints.py
@@ -33,7 +33,7 @@ class TestUserEndPoints(BaseTestClass):
         email_activation_url = message.pop(9)
         resp_verification = self.client.get(
             email_activation_url.split("testserver").pop(1))
-        self.assertEqual(200, resp_verification.status_code)
+        self.assertEqual(302, resp_verification.status_code)
 
     def test_email_verification_fails(self):
         resp = self.client.post(reverse('authentication:signup'),
@@ -50,7 +50,7 @@ class TestUserEndPoints(BaseTestClass):
         """
         resp_verification = self.client.get(
             email_activation_url)
-        self.assertEqual(400, resp_verification.status_code)
+        self.assertEqual(302, resp_verification.status_code)
 
     def test_email_verification_fails_invalid_url_token(self):
         resp = self.client.post(reverse('authentication:signup'),
@@ -74,7 +74,7 @@ class TestUserEndPoints(BaseTestClass):
 
         resp_verification = self.client.get(reverse(
             'authentication:email-verification', args=[self.uuid, self.token+"sdd"]))
-        self.assertEqual(resp_verification.status_code, 400)
+        self.assertEqual(resp_verification.status_code, 302)
 
     def test_login_user_with_valid_data(self):
         """ 
@@ -172,7 +172,7 @@ class TestUserEndPoints(BaseTestClass):
 
         resp = self.client.get(self.reset_password_url,
                                content_type='application/json')
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 302)
 
     def test_user_reset_password_has_valid_token_fails(self):
         resp = self.client.post(reverse('authentication:request-password-reset'),
@@ -185,7 +185,7 @@ class TestUserEndPoints(BaseTestClass):
 
         resp = self.client.get(
             self.reset_password_url_invalid, content_type='application/json')
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 302)
 
     def test_retrieve_user_success(self):
         """This tests for a successful retrival of a registered user"""

--- a/authors/apps/core/models.py
+++ b/authors/apps/core/models.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 import jwt
 import datetime
 from authors.apps.notifications.utils import permissions
+import urllib.parse
 
 class PasswordResetManager:
     """
@@ -98,9 +99,21 @@ class EmailNotificationDispatch:
         
     def build_and_send(self, request, notification, notification_permission):
         self.receiver_email = notification.receiver.user.email
-        opt_out_url = request.build_absolute_uri(reverse('notifications:perms', kwargs={'permission_type': self.make_token(self.receiver_email, notification_permission)}))
-        opt_out_all_url = request.build_absolute_uri(reverse('notifications:perms', kwargs={'permission_type': self.make_token(self.receiver_email, permissions.RECEIVE_NOTIFICATION_EMAILS)}))
-    
+        opt_out_url = settings.FRONTEND_BASE_URL + \
+                        reverse('notifications:perms', \
+                            kwargs={'permission_type': \
+                                    self.make_token(self.receiver_email, \
+                                    notification_permission)})[4:]
+
+        opt_out_all_url =  settings.FRONTEND_BASE_URL + \
+                            reverse('notifications:perms',\
+                                kwargs={'permission_type': 
+                                self.make_token(self.receiver_email, \
+                                permissions.RECEIVE_NOTIFICATION_EMAILS)})[4:]
+
+        notification.action_link = settings.FRONTEND_BASE_URL + \
+                            urllib.parse.urlparse(
+                                notification.action_link).path[4:]
         context = {
             'username': notification.receiver.user.username,
             'notification_message' : notification.__str__(),

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -187,6 +187,7 @@ REST_FRAMEWORK = {
     ),
 }
 
+FRONTEND_BASE_URL = config('FRONTEND_BASE_URL')
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug in the backend. to allow get requests from links in the email to be redirected to the frontend.

#### How should this be manually tested?
- First `git fetch origin bg-redirect-frontend-163956897 and git checkout bg-redirect-frontend-163956897`
- then add `FRONTEND_BASE_URL` to the `.env` file.
- Then run tests with `python manage.py test`

- On signup, you will receive an email that redirects to the frontend
- On password reset request, you will receive an email that redirects to the frontend

#### What are the relevant pivotal tracker stories?
[#163956897](https://www.pivotaltracker.com/story/show/163956897)
