### PR TITLE
#164244470 Return follow state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -102,6 +102,7 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
 
 class ProfileListSerializer(serializers.ModelSerializer):
     username = serializers.SerializerMethodField()
+    is_following = serializers.SerializerMethodField()
     class Meta:
         model = Profile
         fields = [
@@ -109,8 +110,16 @@ class ProfileListSerializer(serializers.ModelSerializer):
             'first_name',
             'last_name',
             'bio',
-            'image'
+            'image', 
+            'is_following'
         ]
     
     def get_username(self, obj):
         return f"{obj.user.username}"
+
+    def get_is_following(self,obj):
+        """
+        Sets the following status in a user's profile
+        """
+        visitor = self.context['request'].user
+        return True if visitor in obj.followers.all() else False


### PR DESCRIPTION
**What does this PR do?** 
This PR returns the follow-state in the list of profiles. 

**Description of tasks to be implemented**
-  Add _is_following_ attribute to profileListSerialiser.

**How to manually test this?**
- Fetch and check out to this branch using `git fetch origin bg-return-follow-state-164244470 && git checkout bg-return-follow-state-164244470`
- Start server using `python manage.py runserver`
- Make a `GET` request to `http://localhost:8000//api/profiles` to see the 'is_following' attribute returned.

**Related Pivotal Tracker Story**
[#164244470](https://www.pivotaltracker.com/story/show/164244470)