### PR TITLE
#164296745 Adjust the token expiration time

### DIFF
--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -128,7 +128,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         token = jwt.encode(
             {
                 'user_data': token_string,
-                'exp': date_time.now() + timedelta(minutes=30)
+                'exp': date_time.now() + timedelta(hours=5)
             }, settings.SECRET_KEY, algorithm='HS256'
         )
         return token.decode('utf-8')


### PR DESCRIPTION
#### What does this PR do?
This PR prevents users from logging into their accounts every after 30 minutes.

#### Description of Task to be completed?
- Modify the expiration value of the JSON web token

#### How should this be manually tested?

To Test this follow the steps below:
- Fetch and check into this branch with `git fetch origin bg-token-expiration-164296745 && git checkout bg-token-expiration-164296745`
- Start the application by running `python manage.py runserver`
- Login in a registered user then after 30 minutes, access a protected route using the token provided at Login.


#### What are the relevant pivotal tracker stories?
[#164296745](https://www.pivotaltracker.com/story/show/164296745)
