### PR TITLE
#164364291 Add comment Id to comment serializer and user_rated to article serializer

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -9,6 +9,7 @@ from authors.apps.profiles.models import Profile
 from authors.apps.profiles.serializers import UserProfileSerializer
 from authors.apps.utils.estimator import article_read_time
 from authors.apps.utils.share_links import share_links_generator
+from authors.apps.utils.user_rated import get_user_rated
 
 from authors.apps.authentication.models import User
 
@@ -27,6 +28,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     share_links = serializers.SerializerMethodField()
     favorites = serializers.SerializerMethodField()
     read_stats = serializers.SerializerMethodField()
+    user_rated=serializers.SerializerMethodField()
 
     """ 
     Add the field required in the database so as to hold
@@ -39,7 +41,7 @@ class ArticleSerializer(serializers.ModelSerializer):
                   'updated_at', 'favorited', 'favorites', 'favoritesCount',
                   'body', 'image', 'author', 'read_time', 'share_links',
                   'likes_count', 'dislikes_count', 'average_rating', 'read_stats', 
-                  'tags')
+                  'tags','user_rated')
 
     def generate_usernames(self, profiles):
         """
@@ -65,12 +67,16 @@ class ArticleSerializer(serializers.ModelSerializer):
     def get_read_stats(self, obj):
         return ReadStats.objects.filter(article=obj).count()
 
+    def get_user_rated(self,obj):
+        return get_user_rated(self, obj)
+
 
 class ArticleUpdateSerializer(serializers.ModelSerializer):
     author = AuthorProfileSerializer(read_only=True)
     read_time = serializers.SerializerMethodField()
     share_links = serializers.SerializerMethodField()  
     read_stats = serializers.SerializerMethodField()
+    user_rated=serializers.SerializerMethodField()
     
     class Meta:
         model = Article
@@ -91,7 +97,8 @@ class ArticleUpdateSerializer(serializers.ModelSerializer):
             'dislikes_count',
             'read_stats',
             'average_rating',
-            'tags'
+            'tags',
+            'user_rated'
         ]
 
     def get_read_time(self, obj):
@@ -101,7 +108,10 @@ class ArticleUpdateSerializer(serializers.ModelSerializer):
         return share_links_generator(obj, self.context['request'])
     
     def get_read_stats(self, obj):
-        return ReadStats.objects.filter(article=obj).count() 
+        return ReadStats.objects.filter(article=obj).count()
+
+    def get_user_rated(self,obj):
+        return get_user_rated(self, obj)
 
 
 class BookmarksSerializer(serializers.ModelSerializer):

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -9,7 +9,8 @@ class ReplyCommentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CommentReply
-        fields = ('id', 'reply_body', 'repliedOn', 'updatedOn', 'author')
+        fields = ('id', 'reply_body', 'repliedOn', 'updatedOn','comment', 'author',)
+        read_only_fields=('comment',)
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/authors/apps/utils/user_rated.py
+++ b/authors/apps/utils/user_rated.py
@@ -1,0 +1,9 @@
+from authors.apps.articles.models import (
+	ArticleRating)
+	
+
+
+def get_user_rated(self,obj):
+    count = ArticleRating.objects.filter(
+    article_id=obj.pk, user=self.context['request'].user.pk).count()
+    return count<1


### PR DESCRIPTION
**What does this PR do?**
implement returning of a comment id in the body of a comment reply. 
Implements returning of a user_rated field in the article body.

**Tasks to be completed**
- Add a comment field to the comment reply serializer to show id of the parent comment
- Add user_rated filed to articles serializer to show if a user has rated an article
- Add get_user_rated method to serializer class to return user_rated field in articles.

#### How should this be manually tested?
- Fetch and checkout into this branch with `git fetch origin bg-fix-serializer-replies && git checkout bg-fix-serializer-replies`
- run `python manage.py run server`
- perform a get request on the endpoint like `localhost:8000/api/articles/articleslug/comments/commentid/replies` 
- perform a get request on the endpoint like `localhost:8000/api/articles` The response should have a `user_rated` field

**Relevant Pivotal tracker stories**
[[#164364291]](https://www.pivotaltracker.com/story/show/164364291)