### PR TITLE
#164428750 Fix bug preventing users from liking multiple comments and replies

### DIFF
--- a/authors/apps/comments/commentReplyViews.py
+++ b/authors/apps/comments/commentReplyViews.py
@@ -133,7 +133,7 @@ class CommentReplyLikeView(GenericAPIView):
                 Profile, user=self.request.user)
             self.commentReply = get_object_or_404(
                 CommentReply, pk=kwargs.get("reply_id"))
-            CommentReplyLike.objects.get(reply_like_by=self.userProfile)
+            CommentReplyLike.objects.get(reply_like_by=self.userProfile,comment_reply_id=self.commentReply)
            
         except CommentReplyLike.DoesNotExist:
             serializer = self.serializer_class(data={})

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -135,7 +135,7 @@ class CommentLikeView(GenericAPIView):
         self.comment = get_object_or_404(Comment, pk=kwargs.get("pk"))
         self.userProfile = get_object_or_404(Profile, user=self.request.user)
         try:
-            CommentLike.objects.get(liked_by=self.userProfile)
+            CommentLike.objects.get(liked_by=self.userProfile,comment_id=self.comment)
         except CommentLike.DoesNotExist:
             serializer = self.serializer_class(data={})
             serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
#### What does this PR do?
fix bug preventing users from liking more than one comment

#### Description of Task to be completed?
- add a filter to alike by user id and comment like id


#### How should this be manually tested?
- Fetch this branch by running the command `git fetch origin bg-fix-comments-like-164428750` in the terminal and check into the branch `git checkout bg-fix-comments-like-164428750`
- Start the virtual environment `source venv/bin/activate`
- Start the application by running this command: `python manage.py runserver`
- like multiple comments by performing a PUT on `localhost:8000/api/articles/slug/comments/comment-id/like/`
- 

#### Screenshots
[#164428750](https://www.pivotaltracker.com/story/show/164428750)
[Fixes #164428750]